### PR TITLE
add swf to default filePattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For detailed information on how configuration of plugins works, please refer to 
 
 Files matching this pattern will be gzipped.
 
-*Default:* `'\*\*/\*.{js,css,png,gif,jpg,map,xml,txt,svg,eot,ttf,woff,woff2}'`
+*Default:* `'\*\*/\*.{js,css,png,gif,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}'`
 
 ### distDir
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,png,gif,jpg,map,xml,txt,svg,eot,ttf,woff,woff2}',
+        filePattern: '**/*.{js,css,png,gif,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
         zopfli: false,
         distDir: function(context){
           return context.distDir;


### PR DESCRIPTION
swf files are necessary for any app using something like ZeroClipboard. Seems like a common enough need to be included by default. [Matching PR for ember-cli-deploy-manifest](https://github.com/ember-cli-deploy/ember-cli-deploy-manifest/pull/6).