### PR TITLE
Fix #14: only compress uncompressed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ For detailed information on how configuration of plugins works, please refer to 
 ### filePattern
 
 Files matching this pattern will be gzipped.
+Note: image files such as `.png`, `.jpg` and `.gif` should not be gzipped, as they already are compressed.
 
-*Default:* `'\*\*/\*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}'`
+*Default:* `'\*\*/\*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}'`
 
 ### distDir
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,png,gif,ico,jpg,map,xml,txt,svg,swf,eot,ttf,woff,woff2}',
+        filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}',
         zopfli: false,
         keep: false,
         distDir: function(context){


### PR DESCRIPTION
Fixes #14.

I also removed `.swf` from the list and added `.json` while I was at it.

References:

- [What will CloudFlare gzip?](https://support.cloudflare.com/hc/en-us/articles/200168396-What-will-CloudFlare-gzip-)
- [StackOverflow: Is it possible that zipping an swf file results in a bigger file?](http://stackoverflow.com/a/3798308/420747)