### PR TITLE
Add the gzipped file to the context's distFiles when keep is true

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,13 @@ module.exports = {
         return this._gzipFiles(distDir, distFiles, filePattern, keep)
           .then(function(gzippedFiles) {
             self.log('gzipped ' + gzippedFiles.length + ' files ok', { verbose: true });
+            if (keep) {
+              self.log('keep is enabled, added gzipped files to `context.distFiles`', { verbose: true });
+              return {
+                distFiles: gzippedFiles,
+                gzippedFiles: gzippedFiles
+              }
+            }
             return { gzippedFiles: gzippedFiles };
           })
           .catch(this._errorMessage.bind(this));

--- a/tests/unit/index-nodetest.js
+++ b/tests/unit/index-nodetest.js
@@ -155,15 +155,30 @@ describe('gzip plugin', function() {
         });
     });
 
-    it('gzips the matching files with .gz suffix when keep is enabled', function(done) {
-      context.config.gzip.keep = true;
-      return assert.isFulfilled(plugin.willUpload(context))
-        .then(function(result) {
-          assert.deepEqual(result, { gzippedFiles: ['assets/foo.js.gz'] });
-          done();
-        }).catch(function(reason){
-          done(reason);
-        });
+    describe('when keep is enabled', function() {
+      beforeEach(function() {
+        context.config.gzip.keep = true;
+      });
+
+      it('gzips the matching files with .gz suffix', function(done) {
+        return assert.isFulfilled(plugin.willUpload(context))
+          .then(function(result) {
+            assert.deepEqual(result.gzippedFiles, ['assets/foo.js.gz']);
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
+
+      it('adds the gzipped files to the distFiles', function(done) {
+        return assert.isFulfilled(plugin.willUpload(context))
+          .then(function(result) {
+            assert.include(result.distFiles, 'assets/foo.js.gz');
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
By not adding the gzipped files to the distFiles we end up leaving
them out of several things e.g. they're never added to the manifest
for a build and they're never uploaded with the S3 plugin. In much
the same way as the json-config plugin adds the built json file to
the context, this PR will mean the gzip plugin now adds all of the
gzipped files to the context.

Related to https://github.com/ember-cli-deploy/ember-cli-deploy-s3/pull/46