### PR TITLE
Add ignorePattern option for removing specific files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Note: image files such as `.png`, `.jpg` and `.gif` should not be gzipped, as th
 
 *Default:* `'\*\*/\*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}'`
 
+### ignorePattern
+
+Files matching this pattern will *not* be gzipped even if they match filePattern
+
+*Default:* null
+
 ### distDir
 
 The root directory where the files matching `filePattern` will be searched for. By default, this option will use the `distDir` property of the deployment context, provided by [ember-cli-deploy-build][2].


### PR DESCRIPTION
I created this specifically so I could exclude index.json from compression and still include all other .json files.  It may be possible to do this with filePattern alone, but I wasn't able to figure that out feel free to set me straight though.

I wasn't sure about convention in a couple of places - tried to match the style, but I'm happy to fix it up.