### PR TITLE
Remove redis dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "ember-cli-deploy-redis",
+  "name": "ember-cli-deploy-gzip",
   "dependencies": {
     "ember": "1.11.1",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "ember-cli-deploy-plugin": "^0.2.2",
     "ember-cli-babel": "^5.0.0",
     "minimatch": "^2.0.8",
-    "redis": "^0.12.1",
     "rsvp": "^3.0.18"
   },
   "ember-addon": {


### PR DESCRIPTION
This plugin's base was the Redis plugin and the dependency on the
redis package slipped through the net.