### PR TITLE
[security] Update minimatch to ^3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "core-object": "^1.1.0",
     "ember-cli-deploy-plugin": "^0.2.2",
     "ember-cli-babel": "^5.0.0",
-    "minimatch": "^2.0.8",
+    "minimatch": "^3.0.2",
     "rsvp": "^3.0.18"
   },
   "ember-addon": {


### PR DESCRIPTION
## What Changed & Why
minimatch dependency updated to avoid security risk.

Was getting a warning in npm to update to this version to avoid a possibility of a DDOS attack.