### PR TITLE
use RSVP over ember-cli/lib/ext/promise

### DIFF
--- a/bin/changelog
+++ b/bin/changelog
@@ -13,11 +13,11 @@
 
 var EOL       = require('os').EOL;
 var multiline = require('multiline');
-var Promise   = require('ember-cli/lib/ext/promise');
+var RSVP   = require('rsvp');
 var GitHubApi = require('github');
 
 var github         = new GitHubApi({version: '3.0.0'});
-var compareCommits = Promise.denodeify(github.repos.compareCommits);
+var compareCommits = RSVP.denodeify(github.repos.compareCommits);
 var currentVersion = 'v' + require('../package').version;
 
 var user = 'ember-cli-deploy';


### PR DESCRIPTION
ember-cli outputs a depreciation warning when it detects the latter

## What Changed & Why
ember-cli/lib/ext/promise has been deprecated according to ember-cli's output 
![image](https://user-images.githubusercontent.com/766429/31013880-0f529fc4-a510-11e7-933c-30411f02679c.png)

