### PR TITLE
Run in didBuild instead of willUpload

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ ember install ember-cli-deploy-gzip
 For detailed information on what plugin hooks are and how they work, please refer to the [Plugin Documentation][1].
 
 - `configure`
-- `willUpload`
+- `didBuild`
 
 
 ## Configuration Options

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
         }
       },
 
-      willUpload: function(/* context */) {
+      didBuild: function(/* context */) {
         var self = this;
 
         var filePattern     = this.readConfig('filePattern');

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -36,7 +36,7 @@ describe('gzip plugin', function() {
     });
 
     assert.equal(typeof result.configure, 'function');
-    assert.equal(typeof result.willUpload, 'function');
+    assert.equal(typeof result.didBuild, 'function');
   });
 
   describe('configure hook', function() {
@@ -110,7 +110,7 @@ describe('gzip plugin', function() {
     });
   });
 
-  describe('willUpload hook', function() {
+  describe('didBuild hook', function() {
     var plugin;
     var context;
 
@@ -152,7 +152,7 @@ describe('gzip plugin', function() {
     });
 
     it('gzips the matching files which are not ignored', function() {
-      assert.isFulfilled(plugin.willUpload(context))
+      assert.isFulfilled(plugin.didBuild(context))
         .then(function(result) {
           assert.deepEqual(result, { gzippedFiles: ['assets/foo.js'] });
           done();
@@ -167,7 +167,7 @@ describe('gzip plugin', function() {
       });
 
       it('gzips the matching files with .gz suffix', function(done) {
-        assert.isFulfilled(plugin.willUpload(context))
+        assert.isFulfilled(plugin.didBuild(context))
           .then(function(result) {
             assert.deepEqual(result.gzippedFiles, ['assets/foo.js.gz']);
             done();
@@ -177,7 +177,7 @@ describe('gzip plugin', function() {
       });
 
       it('adds the gzipped files to the distFiles', function(done) {
-        assert.isFulfilled(plugin.willUpload(context))
+        assert.isFulfilled(plugin.didBuild(context))
           .then(function(result) {
             assert.include(result.distFiles, 'assets/foo.js.gz');
             done();
@@ -187,7 +187,7 @@ describe('gzip plugin', function() {
       });
 
       it('does not use the same object for gzippedFiles and distFiles', function(done) {
-        assert.isFulfilled(plugin.willUpload(context))
+        assert.isFulfilled(plugin.didBuild(context))
           .then(function(result) {
             assert.notStrictEqual(result.distFiles, result.gzippedFiles);
             done();


### PR DESCRIPTION
## What Changed & Why
I would like to use this plugin in conjunction with [ember-cli-deploy-archive](https://github.com/elidupuis/ember-cli-deploy-archive) (which archives the final build in `didBuild` so we can deploy a single file). 

That isn't possible with the current run order because all this plugin ends up compressing is the final `tar.gz` archive. 

Could this plugin run in `didBuild` based on [pipeline hooks](http://ember-cli-deploy.com/docs/v1.0.x/pipeline-hooks/)? This would make it possible to control the run order using `pipeline.runOrder`.


## Related issues
https://github.com/DockYard/ember-cli-deploy-compress/pull/11

## PR Checklist
- [x] Add tests
- [x] Add documentation
- [x] Prefix documentation-only commits with [DOC]

## People

