### PR TITLE
Skip compressing already compressed font files

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ For detailed information on how configuration of plugins works, please refer to 
 Files matching this pattern will be gzipped.
 Note: image files such as `.png`, `.jpg` and `.gif` should not be gzipped, as they already are compressed.
 
-*Default:* `'\*\*/\*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}'`
+*Default:* `'\*\*/\*.{js,css,json,ico,map,xml,txt,svg,eot,ttf}'`
 
 ### ignorePattern
 

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
     var DeployPlugin = DeployPluginBase.extend({
       name: options.name,
       defaultConfig: {
-        filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf,woff,woff2}',
+        filePattern: '**/*.{js,css,json,ico,map,xml,txt,svg,eot,ttf}',
         ignorePattern: null,
         zopfli: false,
         keep: false,


### PR DESCRIPTION
## What Changed & Why

Woff and Woff2 are specialized formats that are highly
compressed and tend to get bigger when gzipped. They shouldn't be
included in the defaults.

Ref: https://en.wikipedia.org/wiki/Web_Open_Font_Format

## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [ ] Add tests
- [x] Add documentation