### PR TITLE
Keep modification time the same as the original file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 sudo: false
 

--- a/index.js
+++ b/index.js
@@ -93,7 +93,15 @@ module.exports = {
             reject(err);
           });
           out.on('finish', function(){
-            resolve();
+            // set mtime of gz file to mtime of original
+            fs.stat(fullPath, function(err, stats) {
+              if (err) resolve(); // ignore errors
+              else {
+                fs.utimes(outFilePath, Date.now(), stats.mtime, function () {
+                  resolve();
+                });
+              }
+            });
           });
         }).then(function(){
           if(!keep) {

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -151,7 +151,7 @@ describe('gzip plugin', function() {
       return rimraf(context.distDir);
     });
 
-    it('gzips the matching files which are not ignored', function() {
+    it('gzips the matching files which are not ignored', function(done) {
       assert.isFulfilled(plugin.willUpload(context))
         .then(function(result) {
           assert.deepEqual(result, { gzippedFiles: ['assets/foo.js'] });

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -141,6 +141,7 @@ describe('gzip plugin', function() {
       if (!fs.existsSync(context.distDir)) { fs.mkdirSync(context.distDir); }
       if (!fs.existsSync(path.join(context.distDir, 'assets'))) { fs.mkdirSync(path.join(context.distDir, 'assets')); }
       fs.writeFileSync(path.join(context.distDir, context.distFiles[0]), 'alert("Hello foo world!");', 'utf8');
+      fs.utimesSync(path.join(context.distDir, context.distFiles[0]), Date.now(), new Date("2020-01-01T00:01:02Z"));
       fs.writeFileSync(path.join(context.distDir, context.distFiles[1]), 'alert("Hello bar world!");', 'utf8');
       fs.writeFileSync(path.join(context.distDir, context.distFiles[2]), 'alert("Hello ignore world!");', 'utf8');
       plugin.beforeHook(context);
@@ -180,6 +181,20 @@ describe('gzip plugin', function() {
         assert.isFulfilled(plugin.willUpload(context))
           .then(function(result) {
             assert.include(result.distFiles, 'assets/foo.js.gz');
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
+
+      it('has the same timestamp as the original', function(done) {
+        assert.isFulfilled(plugin.willUpload(context))
+          .then(function(result) {
+            var mtime_gz = fs.statSync(path.join(context.distDir, result.gzippedFiles[0])).mtime.valueOf();
+            var mtime_orig = fs.statSync(path.join(context.distDir, context.distFiles[0])).mtime.valueOf();
+
+            assert.strictEqual(mtime_gz, mtime_orig);
+
             done();
           }).catch(function(reason){
             done(reason);


### PR DESCRIPTION
## What Changed & Why

See #32 for the rational.

Copying the modification from the original file should have no bad effects, so it is not necessary being able to introduce a config option for this, IMO.

Also, I have not made it fail if reading / writing the timestamp errors out for some reason.

## Related issues

## PR Checklist
- [x] Add tests
- [ ] Add documentation
- [ ] Prefix documentation-only commits with [DOC]

## People
Mention people who would be interested in the changeset (if any)

@caljess599 FYI