### PR TITLE
Fix invalid atime being set

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
             fs.stat(fullPath, function(err, stats) {
               if (err) resolve(); // ignore errors
               else {
-                fs.utimes(outFilePath, Date.now(), stats.mtime, function () {
+                fs.utimes(outFilePath, new Date(), stats.mtime, function () {
                   resolve();
                 });
               }

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -141,7 +141,7 @@ describe('gzip plugin', function() {
       if (!fs.existsSync(context.distDir)) { fs.mkdirSync(context.distDir); }
       if (!fs.existsSync(path.join(context.distDir, 'assets'))) { fs.mkdirSync(path.join(context.distDir, 'assets')); }
       fs.writeFileSync(path.join(context.distDir, context.distFiles[0]), 'alert("Hello foo world!");', 'utf8');
-      fs.utimesSync(path.join(context.distDir, context.distFiles[0]), Date.now(), new Date("2020-01-01T00:01:02Z"));
+      fs.utimesSync(path.join(context.distDir, context.distFiles[0]), new Date(), new Date("2020-01-01T00:01:02Z"));
       fs.writeFileSync(path.join(context.distDir, context.distFiles[1]), 'alert("Hello bar world!");', 'utf8');
       fs.writeFileSync(path.join(context.distDir, context.distFiles[2]), 'alert("Hello ignore world!");', 'utf8');
       plugin.beforeHook(context);
@@ -187,13 +187,27 @@ describe('gzip plugin', function() {
           });
       });
 
-      it('has the same timestamp as the original', function(done) {
+      it('has the same mtime timestamp as the original', function(done) {
         assert.isFulfilled(plugin.willUpload(context))
           .then(function(result) {
             var mtime_gz = fs.statSync(path.join(context.distDir, result.gzippedFiles[0])).mtime.valueOf();
             var mtime_orig = fs.statSync(path.join(context.distDir, context.distFiles[0])).mtime.valueOf();
 
             assert.strictEqual(mtime_gz, mtime_orig);
+
+            done();
+          }).catch(function(reason){
+            done(reason);
+          });
+      });
+
+      it('atime timestamp is slightly newer than the original', function(done) {
+        assert.isFulfilled(plugin.willUpload(context))
+          .then(function(result) {
+            var atime_gz = fs.statSync(path.join(context.distDir, result.gzippedFiles[0])).atime.valueOf();
+            var atime_orig = fs.statSync(path.join(context.distDir, context.distFiles[0])).atime.valueOf();
+
+            assert.ok(atime_gz - atime_orig < 1000);
 
             done();
           }).catch(function(reason){


### PR DESCRIPTION
## What Changed & Why
It's not super clear from the node docs, but it appears that the value
of atime needs to be in seconds since the eppoc, but Date.now returns milliseconds
which sets the timestamp far into the future. This causes node tar to
die when it attempts to encode this time and finds a very large integer.

We can also pass a Date object directly here so that's what I've done.

This could also copy the access time in the same way we copy the modified time, but it seems better to set it to the created time instead. I'm happy to go either way though.

## Related issues
Link to related issues in this or other repositories (if any)

## PR Checklist
- [x] Add tests

## People
@avdv @lukemelia 
